### PR TITLE
Add dataset statistics display

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,7 @@ This repository contains a Streamlit application that trains a machine learning 
    ```
 
 Use the sidebar to select a house and adjust the voltage drop threshold. The app displays model metrics, voltage drop detection accuracy and feature importances.
+
+## Dataset
+
+The application loads `dataset.csv` at startup and computes basic summary statistics (mean, standard deviation, min and max) for all numeric columns. These statistics are displayed below the model metrics so you can better understand the ranges the model uses when detecting voltage drops.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -21,11 +21,12 @@ st.markdown(
 st.title("🔌 Smart Grid - Gerilim Düşümü Tespiti")
 
 @st.cache_data
-
 def load_data():
-    return pd.read_csv("dataset_1.csv")
+    df = pd.read_csv("dataset.csv")
+    stats = df.describe().T
+    return df, stats
 
-df = load_data()
+df, dataset_stats = load_data()
 
 # --- Sidebar ---
 st.sidebar.header("Filtreler")
@@ -82,6 +83,10 @@ c1, c2, c3 = st.columns(3)
 c1.metric("Doğruluk", f"{accuracy:.2f}")
 c2.metric("Kesinlik", f"{precision:.2f}")
 c3.metric("Duyarlılık", f"{recall:.2f}")
+
+# --- Dataset Summary Statistics ---
+st.subheader("Veri Kümesi İstatistikleri")
+st.dataframe(dataset_stats, use_container_width=True)
 
 # --- Grafik ---
 chart_df = pd.DataFrame({"Gerçek": y_test.values[:200], "Tahmin": y_pred[:200]})


### PR DESCRIPTION
## Summary
- rename dataset to `dataset.csv`
- compute summary statistics when loading data
- display dataset stats in the Streamlit app
- document dataset statistics in the README

## Testing
- `python -m py_compile streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_e_68820e90a79883239e9445fe839b1683