### PR TITLE
Fix README instructions and add LSTM example

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains a Streamlit application that trains a machine learning 
 
 1. Install the dependencies:
    ```bash
-   pip install pandas scikit-learn matplotlib plotly streamlit
+   pip install -r requirements.txt
    ```
 
 2. Start the Streamlit app:
@@ -22,4 +22,8 @@ The application loads `dataset.csv` at startup and computes basic summary statis
 
 ## LSTM (Long Short-Term Memory) – Zaman Serisi Tahmini
 
-Gerilim düşümünü geçmiş verilere bakarak zaman serisi şeklinde tahmin etmek için LSTM tabanlı bir model kullanılabilir. `lstm_forecast.py` dosyası, `dataset.csv` üzerinde temel bir LSTM eğitimi örneği içerir.
+Gerilim düşümünü geçmiş verilere bakarak zaman serisi şeklinde tahmin etmek için LSTM tabanlı bir model de kullanılabilir. `lstm_forecast.py` betiği, `dataset.csv` üzerinde temel bir LSTM eğitimi örneği içerir. Çalıştırmak için aşağıdaki komutu kullanabilirsiniz:
+
+```bash
+python lstm_forecast.py
+```

--- a/lstm_forecast.py
+++ b/lstm_forecast.py
@@ -1,0 +1,55 @@
+import numpy as np
+import pandas as pd
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import MinMaxScaler
+from tensorflow.keras.models import Sequential
+from tensorflow.keras.layers import LSTM, Dense
+
+DATA_FILE = "dataset.csv"
+SEQUENCE_LENGTH = 24
+
+
+def load_series():
+    df = pd.read_csv(DATA_FILE, parse_dates=["Timestamp"])
+    df.sort_values("Timestamp", inplace=True)
+
+    features = [
+        "Voltage (V)",
+        "Current (A)",
+        "Power Consumption (kW)",
+        "Reactive Power (kVAR)"
+    ]
+    target = "Gerilim Düşümü (V)"
+
+    data = df[features + [target]].astype(float)
+    scaler = MinMaxScaler()
+    scaled = scaler.fit_transform(data)
+
+    X, y = [], []
+    for i in range(SEQUENCE_LENGTH, len(scaled)):
+        X.append(scaled[i - SEQUENCE_LENGTH:i, :-1])
+        y.append(scaled[i, -1])
+
+    return np.array(X), np.array(y)
+
+
+def build_model(input_shape):
+    model = Sequential([
+        LSTM(64, input_shape=input_shape),
+        Dense(1)
+    ])
+    model.compile(optimizer="adam", loss="mse")
+    return model
+
+
+if __name__ == "__main__":
+    X, y = load_series()
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, shuffle=False
+    )
+
+    model = build_model((SEQUENCE_LENGTH, X.shape[2]))
+    model.fit(X_train, y_train, epochs=5, batch_size=32, validation_split=0.2)
+
+    loss = model.evaluate(X_test, y_test)
+    print(f"Test Loss: {loss:.4f}")


### PR DESCRIPTION
## Summary
- add `lstm_forecast.py` example for LSTM based forecasting
- update README installation instructions
- document how to run the new LSTM example

## Testing
- `python -m py_compile lstm_forecast.py streamlit_app.py`
- `pip install -q -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688497e88ebc8323a9c3f4f854a7d29d